### PR TITLE
NAVQP-54: clean up USB configuration (two OTG ports).

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-navq.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mp-navq.dts
@@ -724,8 +724,6 @@
                 reg = <0x51>;
                 interrupt-parent = <&gpio4>;
                 interrupts = <28 8>;
-		status = "disabled";
-		fault-status-mask = <0xef>;
 
                 port {
                         typec_dr_sw: endpoint {
@@ -743,7 +741,6 @@
                         sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
                                      PDO_VAR(5000, 20000, 3000)>;
                         op-sink-microwatt = <15000000>;
-                        /* self-powered; */
 
                         ports {
                                 #address-cells = <1>;
@@ -780,12 +777,11 @@
                         label = "USB-C Port2";
                         power-role = "dual";
                         data-role = "dual";
-                        try-power-role = "source";
+                        try-power-role = "sink";
                         source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
                         sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
                                      PDO_VAR(5000, 20000, 3000)>;
                         op-sink-microwatt = <15000000>;
-                        self-powered;
 
                         ports {
                                 #address-cells = <1>;
@@ -1035,6 +1031,7 @@
 
 &usb3_phy0 {
 	status = "okay";
+	vbus-power-supply = <&ptn5110>;
 };
 
 &usb3_0 {
@@ -1067,6 +1064,7 @@
         fsl,pcs-tx-deemph-3p5db = <0x21>;
         fsl,phy-pcs-tx-swing-full = <0x7f>;
 	status = "okay";
+	vbus-power-supply = <&ptn5110_port2>;
 };
 
 &usb3_1 {


### PR DESCRIPTION
1. Enable Type-C controller for USB1.
2. Configure both ports as sinks by default which is beneficial for configuration whert the board is powered by a USB port.
3. Specify VBUS power supplies for USB PHYs (USB/PD).