### PR TITLE
NAVQP-71: perform AR8031 PHY reset sequence during ETH1 init

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx8mp-navq.dts
+++ b/arch/arm64/boot/dts/freescale/imx8mp-navq.dts
@@ -351,6 +351,8 @@
 	pinctrl-0 = <&pinctrl_eqos>;
 	phy-mode = "rgmii-id";  
 	phy-handle = <&ethphy0>;
+	snps,reset-gpios = <&gpio4 22 GPIO_ACTIVE_LOW>;
+	snps,reset-delays-us = <10 10000 20>;
 	status = "okay";
 
 	mdio {
@@ -1218,7 +1220,7 @@
 			MX8MP_IOMUXC_ENET_TD3__ENET_QOS_RGMII_TD3		0x1f
 			MX8MP_IOMUXC_ENET_TX_CTL__ENET_QOS_RGMII_TX_CTL	0x1f
 			MX8MP_IOMUXC_ENET_TXC__CCM_ENET_QOS_CLOCK_GENERATE_TX_CLK	0x1f
-			MX8MP_IOMUXC_SAI2_RXC__GPIO4_IO22		0x19
+			MX8MP_IOMUXC_SAI2_RXC__GPIO4_IO22		0x110
 		>;
 	};
 


### PR DESCRIPTION
This ensures that the PHY is properly reset before the use.